### PR TITLE
Add license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Willi Rath
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/download_cartopy_data.sh
+++ b/bin/download_cartopy_data.sh
@@ -12,7 +12,7 @@ echo ""
 target_dir=$1
 mkdir -p ${target_dir}
 
-# create tmp dir 
+# create tmp dir
 [[ -n ${TMPDIR} ]] || TMPDIR=/tmp
 tmp_dir=${TMPDIR}/`date +%s%N`_get_full_cartopy
 mkdir ${tmp_dir}
@@ -20,9 +20,8 @@ mkdir ${tmp_dir}
 # cd to tmp dir, get cartopy source, download data to repo data path
 (
     cd ${tmp_dir}
-    git clone https://github.com/SciTools/cartopy.git
-    python \
-        cartopy/tools/feature_download.py \
+    wget https://raw.githubusercontent.com/SciTools/cartopy/v0.17.0/tools/feature_download.py
+    python feature_download.py \
         --output ${target_dir} cultural-extra cultural gshhs physical \
         --ignore-repo-data
 )


### PR DESCRIPTION
Download only the script, not the whole cartopy repo. This saves a big download and doesn't require git.